### PR TITLE
Fix: scope rustpoint.io redirect to apex + www only

### DIFF
--- a/infra/terraform/cloudflare.tf
+++ b/infra/terraform/cloudflare.tf
@@ -111,7 +111,7 @@ resource "cloudflare_ruleset" "rustpoint_io_redirect" {
   rules = [{
     ref         = "redirect_io_to_ai"
     description = "Redirect all rustpoint.io traffic to rustpoint.ai"
-    expression  = "true"
+    expression  = "(http.host eq \"rustpoint.io\") or (http.host eq \"www.rustpoint.io\")"
     action      = "redirect"
     action_parameters = {
       from_value = {


### PR DESCRIPTION
## Summary
- `expression = "true"` was redirecting ALL subdomains of rustpoint.io, including staging API (`below-api.staging.rustpoint.io`), causing 522 errors
- Scoped to `(http.host eq "rustpoint.io") or (http.host eq "www.rustpoint.io")`
- **Already applied via Terraform** — this PR syncs the code to match

## Impact
Staging API and all `*.rustpoint.io` Worker custom domains are restored.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Terraform expression change to limit a Cloudflare redirect’s host matching; low complexity and no sensitive logic involved, with the main risk being mis-scoping the redirect for desired hosts.
> 
> **Overview**
> Tightens the Cloudflare redirect ruleset for `rustpoint.io` so the 301 redirect to `rustpoint.ai` only triggers for the apex and `www` hostnames, instead of matching all requests.
> 
> This prevents unintended redirects of `*.rustpoint.io` subdomains (e.g., staging/worker custom domains) while keeping the primary domain redirect behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b891a58c109c73191b4a677b26515728e6ae1040. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->