### PR TITLE
[#6] Add Resend email DNS records to rustpoint.ai

### DIFF
--- a/infra/terraform/cloudflare.tf
+++ b/infra/terraform/cloudflare.tf
@@ -97,6 +97,52 @@ resource "cloudflare_dns_record" "rustpoint_ai_caa_letsencrypt" {
 }
 
 # ===========================================================
+# Email DNS: Resend domain verification for rustpoint.ai
+# Ref: Resend dashboard → Domains → rustpoint.ai
+# ===========================================================
+
+# DKIM signing key (Resend account-specific public key)
+resource "cloudflare_dns_record" "rustpoint_ai_resend_dkim" {
+  zone_id = var.rustpoint_ai_zone_id
+  name    = "resend._domainkey"
+  type    = "TXT"
+  content = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDK5hOfrsYfHxtxIlx1LO0y5da0sYY71YmLm7eJJ4A/EpWewhGEaJn9OnZulZWbZirmaPwF5+MIR/ol7LMraFHkx7AmgDCIUjX/g9Ae10mLPmloGs03dMy1XUK48uwayP3hNuvkEVrES6/KEQ6kfp9O9Ab7RjtPOSNW07m2qinseQIDAQAB"
+  proxied = false
+  ttl     = 1
+}
+
+# MX: SES bounce/feedback routing for send.rustpoint.ai
+resource "cloudflare_dns_record" "rustpoint_ai_send_mx" {
+  zone_id  = var.rustpoint_ai_zone_id
+  name     = "send"
+  type     = "MX"
+  content  = "feedback-smtp.us-east-1.amazonses.com"
+  proxied  = false
+  ttl      = 1
+  priority = 10
+}
+
+# SPF: Authorize SES to send from send.rustpoint.ai
+resource "cloudflare_dns_record" "rustpoint_ai_send_spf" {
+  zone_id = var.rustpoint_ai_zone_id
+  name    = "send"
+  type    = "TXT"
+  content = "v=spf1 include:amazonses.com ~all"
+  proxied = false
+  ttl     = 1
+}
+
+# DMARC policy for rustpoint.ai
+resource "cloudflare_dns_record" "rustpoint_ai_dmarc" {
+  zone_id = var.rustpoint_ai_zone_id
+  name    = "_dmarc"
+  type    = "TXT"
+  content = "v=DMARC1; p=none;"
+  proxied = false
+  ttl     = 1
+}
+
+# ===========================================================
 # Redirect: rustpoint.io → rustpoint.ai (301)
 # Uses Cloudflare Ruleset (http_request_dynamic_redirect phase)
 # ===========================================================


### PR DESCRIPTION
## Summary

- Adds 4 DNS records to `infra/terraform/cloudflare.tf` required for Resend to verify the `rustpoint.ai` sender domain
- Enables `contact@rustpoint.ai` to send transactional email via Resend/SES
- Records sourced directly from Resend dashboard → Domains → rustpoint.ai

## Changes

| Record | Name | Purpose |
|--------|------|---------|
| TXT (DKIM) | `resend._domainkey` | Resend signing key for DKIM authentication |
| MX | `send` | SES bounce/feedback routing |
| TXT (SPF) | `send` | Authorize SES to send from `send.rustpoint.ai` |
| TXT (DMARC) | `_dmarc` | DMARC policy (monitor mode, `p=none`) |

## Testing

1. `terraform plan` — should show 4 new resources, no changes to existing
2. Apply via TFC → Resend dashboard → Domains → click "Verify"
3. Send test email from `contact@rustpoint.ai` via Resend dashboard

> **Note:** DMARC is `p=none` (monitor mode) — appropriate for initial setup. A follow-up issue should add `rua:` reporting tag once deliverability is confirmed.

Closes #6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new DNS records only; risk is limited to potential email deliverability/routing issues if records are misconfigured.
> 
> **Overview**
> Adds Terraform-managed Cloudflare DNS records needed to verify and send email via Resend/SES for `rustpoint.ai`: a DKIM TXT record (`resend._domainkey`), MX + SPF TXT for the `send.rustpoint.ai` subdomain, and a DMARC TXT record (`p=none`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbb27f2fa0c96f5b4d423d9071fcabdd7d114956. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added DNS configuration records to support email delivery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->